### PR TITLE
Remember Text Size

### DIFF
--- a/Pollock/UI/DrawingView.swift
+++ b/Pollock/UI/DrawingView.swift
@@ -494,7 +494,9 @@ public final class DrawingView : UIView {
 
     private func createAndEditTextAtPoint(_ point: CGPoint) {
         let location = Location(point, self.bounds.size)
-        let text = Text("", self.color, location, .arial, self.defaultFontSize)
+        let previousFontSize = UserDefaults.standard.float(forKey: TextDrawingView.kPreviousFontSize)
+        let fontSize = previousFontSize > 0 ? CGFloat(previousFontSize) : self.defaultFontSize
+        let text = Text("", self.color, location, .arial, fontSize)
         self.beginEditingText(text)
     }
  

--- a/Pollock/UI/TextDrawingView.swift
+++ b/Pollock/UI/TextDrawingView.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 
 internal class TextDrawingView : UIView, UITextViewDelegate {
+    static let kPreviousFontSize = "kPreviousFontSize"
     let text: Text
 
     init(_ text: Text) {
@@ -160,6 +161,7 @@ internal class TextDrawingView : UIView, UITextViewDelegate {
 
     @objc private func fontSizeSliderValueChanged(_ sender: UISlider) {
         self.text.fontSize = CGFloat(sender.value)
+        UserDefaults.standard.set(sender.value, forKey: TextDrawingView.kPreviousFontSize)
         self.textView.font = self.text.fontForSize(self.superview?.bounds.size ?? CGSize.zero)
         self.invalidateIntrinsicContentSize()
         self.updateLocation()


### PR DESCRIPTION
Didn’t use the `Loper` framework because I didn't want to introduce additional dependencies on the `Pollock` project.  Instead I used `UserDefaults` to store the text size float between text edits.