### PR TITLE
Remove compressor error for 0 destination size

### DIFF
--- a/Pollock/Data Manager/Compressor.swift
+++ b/Pollock/Data Manager/Compressor.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Compression
 
-struct CompressorError : Error {
+struct CompressorError : CustomNSError {
     let message: String
 
     init(_ message: String) {
@@ -18,6 +18,9 @@ struct CompressorError : Error {
 
     var localizedDescription: String {
         return "CompressorError<\(self.message)>"
+    }
+    var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.message]
     }
 }
 
@@ -103,9 +106,6 @@ final class Compressor {
             case COMPRESSION_STATUS_ERROR:
                 throw CompressorError("Stream process error")
             case COMPRESSION_STATUS_OK:
-                guard stream.dst_size == 0 else {
-                    throw CompressorError("WTF")
-                }
                 output.append(buffer, count: stream.dst_ptr - buffer)
                 stream.dst_ptr = buffer
                 stream.dst_size = bufferSize


### PR DESCRIPTION
Based on the documentation found here -
https://developer.apple.com/documentation/compression/1480976-compressio
n_stream_process?language=objc - A stream destination size of 0 isn’t
necessarily an error.