### PR TITLE
Call culling method when drawing

### DIFF
--- a/Pollock/UI/DrawingView.swift
+++ b/Pollock/UI/DrawingView.swift
@@ -216,6 +216,7 @@ public final class DrawingView : UIView {
         guard self.isEnabled && !self.isTextModeEnabled else {
             return
         }
+        self.currentDrawing?.cullExtraneous(forSize: self.bounds.size)
         self.currentDrawing?.prune()
         self.currentDrawing = nil
         self.process(touches, forEvent: event)


### PR DESCRIPTION
The Apple Pencil was creating ~50 points when trying to draw a dot.
This culling call will remove unnecessary points from being included in
the drawing API.