### PR TITLE
Fix conversion bug for JSON parsing on 32bit devices

### DIFF
--- a/Pollock/Data Structure/Location.swift
+++ b/Pollock/Data Structure/Location.swift
@@ -18,14 +18,14 @@ internal struct Location : Serializable {
     }
 
     init(_ payload: [String : Any]) throws {
-        guard let xOffset = payload["xOffset"] as? CGFloat else {
+        guard let xOffset = payload["xOffset"] as? Double else {
             throw SerializerError("Missing xOffset for Location")
         }
-        guard let yOffset = payload["yOffset"] as? CGFloat else {
+        guard let yOffset = payload["yOffset"] as? Double else {
             throw SerializerError("Missing yOffset for Location")
         }
-        self.xOffset = xOffset
-        self.yOffset = yOffset
+        self.xOffset = CGFloat(xOffset)
+        self.yOffset = CGFloat(yOffset)
     }
 
     func serialize() throws -> [String : Any] {

--- a/Pollock/Data Structure/Point.swift
+++ b/Pollock/Data Structure/Point.swift
@@ -46,7 +46,7 @@ internal struct Point : Serializable {
     init(_ payload: [String : Any]) throws {
         self.previous = try Location.load(payload["previous"])
         self.location = try Location.load(payload["location"])
-        self.force = payload["force"] as? CGFloat ?? 1.0
+        self.force = CGFloat(payload["force"] as? Double ?? 1.0)
         self.isPredictive = payload["isPredictive"] as? Bool ?? false
     }
 }

--- a/Pollock/Data Structure/Tools/HighlighterTool.swift
+++ b/Pollock/Data Structure/Tools/HighlighterTool.swift
@@ -25,8 +25,8 @@ public final class HighlighterTool : Tool {
     public required init(_ payload: [String : Any]) throws {
         super.init()
         self.version = try Serializer.validateVersion(payload["version"], "HighlighterTool")
-        self.lineWidth = payload["lineWidth"] as? CGFloat ?? 16.0
-        self.forceSensitivity = payload["forceSensitivity"] as? CGFloat ?? 1.0
+        self.lineWidth = CGFloat(payload["lineWidth"] as? Double ?? 1.0)
+        self.forceSensitivity = CGFloat(payload["forceSensitivity"] as? Double ?? 1.0)
     }
 
     public override var localizedUndoName: String {

--- a/Pollock/Data Structure/Tools/PenTool.swift
+++ b/Pollock/Data Structure/Tools/PenTool.swift
@@ -25,8 +25,8 @@ public final class PenTool : Tool {
     public required init(_ payload: [String : Any]) throws {
         super.init()
         self.version = try Serializer.validateVersion(payload["version"], "PenTool")
-        self.lineWidth = payload["lineWidth"] as? CGFloat ?? 16.0
-        self.forceSensitivity = payload["forceSensitivity"] as? CGFloat ?? 8.0
+        self.lineWidth = CGFloat(payload["lineWidth"] as? Double ?? 1.0)
+        self.forceSensitivity = CGFloat(payload["forceSensitivity"] as? Double ?? 1.0)
     }
 
     public override var localizedUndoName: String {

--- a/Pollock/Utils/CGPoint.swift
+++ b/Pollock/Utils/CGPoint.swift
@@ -25,13 +25,13 @@ internal extension CGPoint {
 
 extension CGPoint : Serializable {
     public init(_ payload: [String : Any]) throws {
-        guard let x = payload["x"] as? CGFloat else {
+        guard let x = payload["x"] as? Double else {
             throw SerializerError("Size missing width")
         }
-        guard let y = payload["y"] as? CGFloat else {
+        guard let y = payload["y"] as? Double else {
             throw SerializerError("Size missing height")
         }
-        self.init(x: x, y: y)
+        self.init(x: CGFloat(x), y: CGFloat(y))
     }
 
     public func serialize() throws -> [String : Any] {

--- a/Pollock/Utils/CGSize.swift
+++ b/Pollock/Utils/CGSize.swift
@@ -10,13 +10,13 @@ import Foundation
 
 extension CGSize : Serializable {
     public init(_ payload: [String : Any]) throws {
-        guard let width = payload["width"] as? CGFloat else {
+        guard let width = payload["width"] as? Double else {
             throw SerializerError("Size missing width")
         }
-        guard let height = payload["height"] as? CGFloat else {
+        guard let height = payload["height"] as? Double else {
             throw SerializerError("Size missing height")
         }
-        self.init(width: width, height: height)
+        self.init(width: CGFloat(width), height: CGFloat(height))
     }
 
     public func serialize() throws -> [String : Any] {


### PR DESCRIPTION
Better 32bit architecture support.

Changed the parsing logic to convert Any type values to Double first, before converting to CGFloat.  Casting CGFloat's from the JSON values fail, causing annotations to not render.